### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Build and publish an image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
 
       with:
         name: brighteyed/yttg/yttg


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore